### PR TITLE
Fix confliction with code block and inlined code

### DIFF
--- a/dist/lib/filter.js
+++ b/dist/lib/filter.js
@@ -2,6 +2,11 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const katex_1 = require("katex");
 const he_1 = require("he");
+const EXCLUDE_TAG = [
+    'escape',
+    'pre',
+    'code'
+];
 function filter(data) {
     const displayRegExp = new RegExp("\\$\\$[^\\$]*\\$\\$", "mg");
     data.content = data.content.replace(displayRegExp, (s) => {
@@ -9,10 +14,44 @@ function filter(data) {
             displayMode: true
         });
     });
-    const regexp = new RegExp("\\$([^\\$]*)\\$", "mg");
-    data.content = data.content.replace(regexp, (s) => {
-        return katex_1.renderToString(he_1.unescape(s).slice(1, -1).trim());
+    let contents = data.content;
+    let splits = contents.split(/[\r\n]/);
+    var regTags = /^<([\w]+)>/;
+    splits.forEach((line, ind) => {
+        let linetrim = line.trim();
+        // skip parsing inside codes
+        let htmlTagMatch = linetrim.match(regTags);
+        if (htmlTagMatch != null) {
+            let tag = htmlTagMatch[1];
+            if (EXCLUDE_TAG.includes(tag)) {
+                return;
+            }
+        }
+        //parse single line katex
+        var pendingLine = line;
+        let linepart = [];
+        const regMath = /\$([^\$]+)\$/;
+        let mathMatch = pendingLine.match(regMath);
+        while (mathMatch != null) {
+            let mathc = mathMatch[1];
+            if (!mathc.replace(/\\`/g, '').includes('`')) {
+                let katexc = katex_1.renderToString(he_1.unescape(mathc));
+                let posind = mathMatch.index + mathMatch[0].length;
+                let sub1 = pendingLine.substr(0, posind);
+                linepart.push(sub1.replace(mathMatch[0], katexc));
+                let sub2 = pendingLine.substr(posind);
+                pendingLine = sub2;
+            }
+            else {
+                linepart.push(pendingLine.substr(0, mathMatch.index + 1));
+                pendingLine = pendingLine.substr(mathMatch.index + 1);
+            }
+            mathMatch = pendingLine.match(regMath);
+        }
+        linepart.push(pendingLine);
+        splits[ind] = linepart.join('');
     });
+    data.content = splits.join('\n');
     return data;
 }
 exports.filter = filter;

--- a/dist/lib/filter.spec.js
+++ b/dist/lib/filter.spec.js
@@ -53,4 +53,27 @@ This is a formula: $$E = mc^2$$.
         expect(responseContent).not.toContain("$");
         expect(responseContent).toMatchSnapshot();
     });
+    it("skip inside code block", () => {
+        const content = `
+        <code>var x = $(xxx); y = $ (aa);</code>
+      `;
+        const { content: responseContent } = filter_1.filter({ content });
+        expect(responseContent).toEqual(content);
+        expect(responseContent).not.toContain("katex");
+        expect(responseContent).toContain("(xxx); y = ");
+    });
+    it("skip inside inline code", () => {
+        const content = '`var x = $test; `  ` var y = $y;`';
+        const { content: responseContent } = filter_1.filter({ content });
+        expect(responseContent).toEqual(content);
+        expect(responseContent).not.toContain("katex");
+        expect(responseContent).toContain("test; `  ` var y = ");
+    });
+    it("latex with '`' ", () => {
+        const content = '$ \\text{ \\`{a} }$ `test inline code contains  $`';
+        const { content: responseContent } = filter_1.filter({ content });
+        expect(responseContent).not.toEqual(content);
+        expect(responseContent).toContain("katex");
+        expect(responseContent).not.toContain("$ \\text{ \\`{a} }$");
+    });
 });

--- a/src/lib/filter.spec.ts
+++ b/src/lib/filter.spec.ts
@@ -55,4 +55,34 @@ This is a formula: $$E = mc^2$$.
     expect(responseContent).not.toContain("$");
     expect(responseContent).toMatchSnapshot();
   });
+
+  it("skip inside code block", () => {
+    const content = `
+        <code>var x = $(xxx); y = $ (aa);</code>
+      `;
+      const { content: responseContent } = filter({ content });
+      expect(responseContent).toEqual(content);
+      expect(responseContent).not.toContain("katex");
+      expect(responseContent).toContain("(xxx); y = ");
+  });
+
+  it("skip inside inline code", () => {
+    const content = '`var x = $test; `  ` var y = $y;`';
+      const { content: responseContent } = filter({ content });
+      expect(responseContent).toEqual(content);
+      expect(responseContent).not.toContain("katex");
+      expect(responseContent).toContain("test; `  ` var y = ");
+  });
+
+
+  it("latex with '`' ", () => {
+    const content = '$ \\text{ \\`{a} }$ `test inline code contains  $`';
+      const { content: responseContent } = filter({ content });
+      expect(responseContent).not.toEqual(content);
+      expect(responseContent).toContain("katex");
+      expect(responseContent).not.toContain("$ \\text{ \\`{a} }$");
+  });
+
+
+  
 });

--- a/src/lib/filter.ts
+++ b/src/lib/filter.ts
@@ -1,7 +1,14 @@
 import { renderToString } from "katex";
 import { unescape } from "he";
 
+const EXCLUDE_TAG: string[] = [
+  'escape',
+  'pre',
+  'code'
+];
+
 export function filter(data: { content: string }) {
+
   const displayRegExp = new RegExp("\\$\\$[^\\$]*\\$\\$", "mg");
   data.content = data.content.replace(displayRegExp, (s: string) => {
     return renderToString(unescape(s).slice(2, -2).trim(), {
@@ -9,9 +16,53 @@ export function filter(data: { content: string }) {
     });
   });
 
-  const regexp = new RegExp("\\$([^\\$]*)\\$", "mg");
-  data.content = data.content.replace(regexp, (s: string) => {
-    return renderToString(unescape(s).slice(1, -1).trim());
+  let contents = data.content;
+  let splits = contents.split(/[\r\n]/);
+  var regTags = /^<([\w]+)>/
+
+  splits.forEach((line, ind) => {
+
+    let linetrim = line.trim();
+
+    // skip parsing inside codes
+    let htmlTagMatch = linetrim.match(regTags);
+    if (htmlTagMatch != null) {
+      let tag = htmlTagMatch[1];
+      if (EXCLUDE_TAG.includes(tag)) {
+        return;
+      }
+    }
+
+    //parse single line katex
+    var pendingLine = line;
+    let linepart = [];
+
+    const regMath = /\$([^\$]+)\$/
+    let mathMatch: any = pendingLine.match(regMath);
+
+    while (mathMatch != null) {
+      let mathc = mathMatch[1];
+
+      if (!mathc.replace(/\\`/g, '').includes('`')) {
+        let katexc = renderToString(unescape(mathc));
+        let posind = mathMatch.index + mathMatch[0].length;
+
+        let sub1 = pendingLine.substr(0, posind);
+        linepart.push(sub1.replace(mathMatch[0], katexc));
+        let sub2 = pendingLine.substr(posind);
+        pendingLine = sub2;
+      }
+      else {
+        linepart.push(pendingLine.substr(0, mathMatch.index + 1));
+        pendingLine = pendingLine.substr(mathMatch.index + 1);
+      }
+      mathMatch = pendingLine.match(regMath);
+    }
+
+    linepart.push(pendingLine);
+    splits[ind] = linepart.join('');
   });
+
+  data.content = splits.join('\n');
   return data;
 }


### PR DESCRIPTION
Fix some corner cases when using katex combined with code.

+ code block contains ambigous `$` marks  => keep
<pre>
```php
var x = $a + $b
```
</pre>
+ inline code contains `$` marks   => keep
<pre>
`$(PATH)` `${ENV}`
</pre>   
+ katex formula contains <code>`</code> => parsing correctly,  <code>$ and $$</code> has higher priorty
<pre>
$ \text{ \`{a} }$  `test inline code contains  $`
</pre>

---
existing unit-test cases passed.
add three new test cases.